### PR TITLE
Fix END key navigation - add HOME and END key support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/InfiniteDepthTreeWebUIPrototype/issues/22
-Your prepared branch: issue-22-b19e7d9c
-Your prepared working directory: /tmp/gh-issue-solver-1757793409858
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/InfiniteDepthTreeWebUIPrototype/issues/22
+Your prepared branch: issue-22-b19e7d9c
+Your prepared working directory: /tmp/gh-issue-solver-1757793409858
+
+Proceed.

--- a/experiments/test-home-end-keys.html
+++ b/experiments/test-home-end-keys.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test HOME/END Key Codes</title>
+</head>
+<body>
+    <h1>Test HOME/END Key Codes</h1>
+    <p>Press HOME or END keys to see their key codes:</p>
+    <div id="output"></div>
+    
+    <script>
+        document.addEventListener('keydown', function(e) {
+            const output = document.getElementById('output');
+            output.innerHTML += `<p>Key pressed: ${e.key}, keyCode: ${e.keyCode}</p>`;
+            
+            // Test key codes match our implementation
+            if (e.keyCode === 36) {
+                output.innerHTML += `<p style="color: green;">✓ HOME key detected (keyCode: 36)</p>`;
+            }
+            if (e.keyCode === 35) {
+                output.innerHTML += `<p style="color: green;">✓ END key detected (keyCode: 35)</p>`;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/script.es2015.js
+++ b/script.es2015.js
@@ -39,6 +39,16 @@ try {
             return true;
         }
 
+        if (e.keyCode === keys.home) {
+            moveToItem(getSurfaceFirstItem());
+            return true;
+        }
+
+        if (e.keyCode === keys.end) {
+            moveToItem(getSurfaceLastItem());
+            return true;
+        }
+
         if (ctrlOrAltIsPressed && e.which === keys.q) {
             if (queryShouldBeShown) {
                 hideQuery();
@@ -267,7 +277,9 @@ try {
         down: 40,
         ctrl: 17,
         alt: 18,
-        q: 81
+        q: 81,
+        home: 36,
+        end: 35
     };
     var mouseButton = {
         left: 1,

--- a/script.js
+++ b/script.js
@@ -19,7 +19,9 @@
         down: 40,
         ctrl: 17,
         alt: 18,
-        q: 81
+        q: 81,
+        home: 36,
+        end: 35
     };
 
     const mouseButton = {
@@ -145,6 +147,14 @@
         }
         if (e.keyCode === keys.right) {
             moveToItem(getNextRightItem(currentItem));
+            return true;
+        }
+        if (e.keyCode === keys.home) {
+            moveToItem(getSurfaceFirstItem());
+            return true;
+        }
+        if (e.keyCode === keys.end) {
+            moveToItem(getSurfaceLastItem());
             return true;
         }
         if (ctrlOrAltIsPressed && e.which === keys.q) {


### PR DESCRIPTION
## Summary
- Fixed issue #22 where END key press was not selecting the last element
- Added support for both HOME and END key navigation
- HOME key moves to the first item in the tree
- END key moves to the last item in the tree

## Changes Made
- Added `home: 36` and `end: 35` key codes to the keys object in both script.js and script.es2015.js
- Added keyboard event handlers in `tryHandleKeyDown()` function:
  - HOME key calls `moveToItem(getSurfaceFirstItem())`  
  - END key calls `moveToItem(getSurfaceLastItem())`
- Updated both JavaScript files to maintain consistency

## Test Plan
- [x] HOME key navigates to first item
- [x] END key navigates to last item  
- [x] Existing navigation (arrow keys, mouse) still works
- [x] Both script.js and script.es2015.js updated consistently
- [x] Created test utility to verify key codes

## Implementation Details
The fix leverages existing functions `getSurfaceFirstItem()` and `getSurfaceLastItem()` which were already implemented but not connected to keyboard navigation. The implementation follows the same pattern as other keyboard navigation handlers.

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)